### PR TITLE
회원가입, 로그인 정상화 / 불필요한 주석 코드 삭제(본 서비스와 관련 없는 코드들 삭제), 설명 주석 유지

### DIFF
--- a/src/main/java/com/sparta/instagram_clone_sv/domain/user/UserRepository.java
+++ b/src/main/java/com/sparta/instagram_clone_sv/domain/user/UserRepository.java
@@ -8,5 +8,5 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUsername(String username);
     Optional<User> findByEmail(String email);
-    Optional<User> findByRealname(String realname);
+    Optional<User> findByNickname(String nickname);
 }

--- a/src/main/java/com/sparta/instagram_clone_sv/service/UserService.java
+++ b/src/main/java/com/sparta/instagram_clone_sv/service/UserService.java
@@ -53,6 +53,9 @@ public class UserService {
 
     // 회원가입
     public void registerUser(@Valid @RequestBody SignupRequestDto signupRequestDto) {
+        // 회원 닉네임(활동명) 입력
+        String nickname = signupRequestDto.getNickname();
+        // 유저명 입력
         String username = signupRequestDto.getUsername();
         String errorMessage;
         // 중복 이메일 확인
@@ -61,12 +64,7 @@ public class UserService {
             errorMessage = "중복된 email이 존재합니다.";
             throw new UserRequestException(errorMessage);
         }
-        // 회원 실명 중복 확인
-        String realname = signupRequestDto.getRealname();
-        if (userRepository.findByRealname(realname).isPresent()) {
-            errorMessage = "중복된 실명이 존재합니다.";
-            throw new UserRequestException(errorMessage);
-        }
+
         // 회원 ID 중복 확인
         Optional<User> found = userRepository.findByUsername(username);
         if (found.isPresent()) {
@@ -84,30 +82,18 @@ public class UserService {
             errorMessage = "이메일을 포함한 비밀번호는 사용불가합니다.";
             throw new UserRequestException(errorMessage);
         }
-        // 패스워드 속에 실명 중복 없애기
-        if(signupRequestDto.getPassword().contains(realname) || realname.contains(signupRequestDto.getPassword())) {
-            errorMessage = "실명을 포함한 비밀번호는 사용불가합니다.";
+        // 패스워드 속에 닉네임 중복 없애기
+        if(signupRequestDto.getPassword().contains(nickname) || nickname.contains(signupRequestDto.getPassword())) {
+            errorMessage = "닉네임을 포함한 비밀번호는 사용불가합니다.";
             throw new UserRequestException(errorMessage);
         }
 
-        ////////// 비밀번호 재확인(클론코딩 상 요구사항 아니므로 삭제 //////////
-//        if (!signupRequestDto.getPassword().equals(signupRequestDto.getRepassword())) {
-//            errorMessage = "비밀번호가 일치하지 않습니다.";
-//            throw new UserRequestException(errorMessage);
-//        }
         // 패스워드 인코딩
         String password = passwordEncoder.encode(signupRequestDto.getPassword());
 
         /// 위의 조건을 다 통과한 경우에 한해 userRepository.save 가능함 ///
-        User user = new User(email, realname, username, password);
+        User user = new User(true, username, email, nickname, password);
         userRepository.save(user);
     }
-
-    ////// 유저 비밀번호 변경(update) 관련 부분 //////
-//    @Transactional
-//    public void update(String newPass, User user){
-//        user.setPassword(passwordEncoder.encode(newPass));
-//        userRepository.save(user);
-//    }
 }
 

--- a/src/main/java/com/sparta/instagram_clone_sv/web/controller/UserApiController.java
+++ b/src/main/java/com/sparta/instagram_clone_sv/web/controller/UserApiController.java
@@ -34,7 +34,7 @@ public class UserApiController {
 
     // 회원 가입 요청 처리
     @ApiOperation("회원가입")
-    @PostMapping("/api/signup")
+    @PostMapping("/signup")
     public void registerUser(@Valid @RequestBody SignupRequestDto signupRequestDto, Errors errors) {
         if (errors.hasErrors()) {
             userService.validateHandling(errors);
@@ -43,7 +43,7 @@ public class UserApiController {
     }
 
     // 로그인
-    @PostMapping("/user/login")
+    @PostMapping("/login")
     public List<Map<String,String>> login(@RequestBody Map<String, String> user) {
         User member = userRepository.findByUsername(user.get("username"))
                 .orElseThrow(() -> new UserRequestException("가입되지 않은 회원입니다."));

--- a/src/main/java/com/sparta/instagram_clone_sv/web/dto/SignupRequestDto.java
+++ b/src/main/java/com/sparta/instagram_clone_sv/web/dto/SignupRequestDto.java
@@ -16,16 +16,12 @@ public class SignupRequestDto {
     @Email(message = "이메일 형식에 맞지 않습니다.")
     private String email;
 
-    @NotBlank(message = "실명은 필수 입력 값입니다.")
-    private String realname;
+    @NotBlank(message = "닉네임은 필수 입력 값입니다.")
+    private String nickname;
 
     @NotBlank(message = "유저명은 필수 입력 값입니다.")
     private String username;
 
     @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
     private String password;
-
-////////// 비밀번호 재확인(클론코딩 상 요구사항 아니므로 삭제 //////////
-//    @NotBlank(message = "비밀번호는 확인이 필요합니다.")
-//    private String repassword;
 }


### PR DESCRIPTION
회원가입 시 "realname" -> "nickname" 변경 / 에러메시지 변경 / DB 내 타 유저와 중복 허용
로그인 시 "username"과 "token"을 response
[
  {
    "username": "ekerl2"
  },
  {
    "token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJla2VybDIiLCJlbWFpbCI6ImVrZXJsMkBuYXZlci5jb20iLCJpYXQiOjE2MjY2MTg4MDAsImV4cCI6MTYyNjcwNTIwMH0.pN7UwWL2qnKf92HtNxabHuethl_W1n0HrZMTnk-kVZA"
  }
]
 3. 로그인, 회원가입 API URL 수정
기존 : /user/login, /user/signup
변경 : /login, /signup